### PR TITLE
fix: update to purs 0.14

### DIFF
--- a/src/Record/CSV/Header.purs
+++ b/src/Record/CSV/Header.purs
@@ -12,7 +12,7 @@ import Record.CSV.Type (CSVLine)
 import Type.Data.RowList (RLProxy(..))
 import Type.Proxy (Proxy)
 
-class Header (rl :: RL.RowList) where
+class Header (rl :: RL.RowList Type) where
   headerProxy :: RLProxy rl -> CSVLine
 
 instance headerNil :: Header RL.Nil where

--- a/src/Record/CSV/Parser/ParseValues.purs
+++ b/src/Record/CSV/Parser/ParseValues.purs
@@ -16,7 +16,7 @@ import Record.CSV.Parser.FromCSV (class FromCSV, fromCSV)
 import Record.CSV.Type (CSVResult, CSVLine)
 import Type.Data.RowList (RLProxy(..))
 
-class ParseValues (rl :: RL.RowList) (r :: # Type) | rl -> r where
+class ParseValues (rl :: RL.RowList Type) (r :: Row Type) | rl -> r where
   parseProxy :: RLProxy rl -> CSVLine -> CSVResult { | r }
 
 instance parseValuesNil :: ParseValues RL.Nil () where

--- a/src/Record/CSV/Printer/HeaderConstraint.purs
+++ b/src/Record/CSV/Printer/HeaderConstraint.purs
@@ -4,10 +4,10 @@ module Record.CSV.Printer.HeaderConstraint
   ) where
 
 import Prim.RowList as RL
-import Record.CSV.Printer.SList (SCons, SNil, kind SList)
+import Record.CSV.Printer.SList (SCons, SNil, SList)
 import Type.RowList (class ListToRow)
 
-class HeaderConstraint (sl :: SList) (r :: # Type) | sl -> r
+class HeaderConstraint (sl :: SList) (r :: Row Type) | sl -> r
 
 instance headerConstraint ::
   ( RL.RowToList r rl
@@ -16,7 +16,7 @@ instance headerConstraint ::
   ) =>
   HeaderConstraint sl r
 
-class SameNames (sl :: SList) (rl :: RL.RowList) | sl -> rl
+class SameNames (sl :: SList) (rl :: RL.RowList Type) | sl -> rl
 
 instance sameNamesNil :: SameNames SNil RL.Nil
 

--- a/src/Record/CSV/Printer/PrintValues.purs
+++ b/src/Record/CSV/Printer/PrintValues.purs
@@ -13,7 +13,7 @@ import Record as Record
 import Record.CSV.Printer.ToCSV (class ToCSV, toCSV)
 import Type.Data.RowList (RLProxy(..))
 
-class PrintValues (rl :: RL.RowList) (r :: # Type) | rl -> r where
+class PrintValues (rl :: RL.RowList Type) (r :: Row Type) | rl -> r where
   printProxy :: RLProxy rl -> { | r } -> L.List String
 
 instance printValuesNil :: PrintValues RL.Nil () where

--- a/test/CustomType.purs
+++ b/test/CustomType.purs
@@ -3,7 +3,7 @@ module Test.CustomType where
 import Prelude
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Data.List as L
 import Record.CSV.Error (csvError)
 import Record.CSV.Parser (parseCSV)


### PR DESCRIPTION
```
sd 'Data.Generic.Rep.Show' 'Data.Show.Generic' $(fd --no-ignore --hidden --type f .purs .)
sd 'Data.Generic.Rep.Eq' 'Data.Eq.Generic' $(fd --no-ignore --hidden --type f .purs .)
sd 'Data.Generic.Rep.Ord' 'Data.Ord.Generic' $(fd --no-ignore --hidden --type f .purs .)
sd 'Data.Argonaut.Decode.Generic.Rep' 'Data.Argonaut.Decode.Generic' $(fd --no-ignore --hidden --type f .purs .)
sd 'Data.Argonaut.Encode.Generic.Rep' 'Data.Argonaut.Encode.Generic' $(fd --no-ignore --hidden --type f .purs .)
sd 'Data.Char.Unicode' 'Data.String.Unicode' $(fd --no-ignore --hidden --type f .purs .)
sd 'Data.Bifunctor.Wrap' 'Data.Functor.Wrap' $(fd --no-ignore --hidden --type f .purs .)
sd '\# Type' 'Row Type' $(fd --no-ignore --hidden --type f .purs .)
sd 'RowList\) ' 'RowList Type) ' $(fd --no-ignore --hidden --type f .purs .)
```